### PR TITLE
Unknown traj shape

### DIFF
--- a/tfkbnufft/__init__.py
+++ b/tfkbnufft/__init__.py
@@ -1,6 +1,6 @@
 """Package info"""
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __author__ = 'Zaccharie Ramzi'
 __author_email__ = 'zaccharie.ramzi@inria.fr'
 __license__ = 'MIT'

--- a/tfkbnufft/nufft/interp_functions.py
+++ b/tfkbnufft/nufft/interp_functions.py
@@ -30,8 +30,8 @@ def calc_coef_and_indices(tm, kofflist, Jval, table, centers, L, dims, conjcoef=
     int_type = tf.int64
 
     # array shapes
-    M = tm.shape[1]
-    ndims = tm.shape[0]
+    M = tf.shape(tm)[1]
+    ndims = tf.shape(tm)[0]
 
     # indexing locations
     gridind = tf.cast(kofflist + Jval[:, None], dtype)

--- a/tfkbnufft/nufft/interp_functions.py
+++ b/tfkbnufft/nufft/interp_functions.py
@@ -31,7 +31,7 @@ def calc_coef_and_indices(tm, kofflist, Jval, table, centers, L, dims, conjcoef=
 
     # array shapes
     M = tf.shape(tm)[1]
-    ndims = tf.shape(tm)[0]
+    ndims = tm.shape[0]
 
     # indexing locations
     gridind = tf.cast(kofflist + Jval[:, None], dtype)


### PR DESCRIPTION
This PR allows to use tfkbnufft with trajectories whose shape (i.e. number of sample points) is not known at tracing time.
The number of dimension (i.e. 2D or 3D) should be known at tracing however.

This should fix https://github.com/zaccharieramzi/fastmri-reproducible-benchmark/issues/76.