### PR TITLE
Make gradient of DC estimation to zero based on an argument

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 pip install torch==1.7 torchkbnufft==0.3.4 scikit-image pytest
 # We test ndft_test.py separately as it causes some issues with tracing resulting in hangs.
 python -m pytest tfkbnufft --ignore=tfkbnufft/tests/ndft_test.py

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 pip install torch==1.7 torchkbnufft==0.3.4 scikit-image pytest
+# We test ndft_test.py separately as it causes some issues with tracing resulting in hangs.
 python -m pytest tfkbnufft --ignore=tfkbnufft/tests/ndft_test.py
 python -m pytest tfkbnufft/tests/ndft_test.py

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x
+set -e
 pip install torch==1.7 torchkbnufft==0.3.4 scikit-image pytest
 # We test ndft_test.py separately as it causes some issues with tracing resulting in hangs.
 python -m pytest tfkbnufft --ignore=tfkbnufft/tests/ndft_test.py

--- a/tfkbnufft/__init__.py
+++ b/tfkbnufft/__init__.py
@@ -1,6 +1,6 @@
 """Package info"""
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 __author__ = 'Zaccharie Ramzi'
 __author_email__ = 'zaccharie.ramzi@inria.fr'
 __license__ = 'MIT'

--- a/tfkbnufft/mri/dcomp_calc.py
+++ b/tfkbnufft/mri/dcomp_calc.py
@@ -85,19 +85,6 @@ def calculate_radial_dcomp_tf(interpob, nufftob_forw, nufftob_back, ktraj, stack
     return dcomp
 
 
-
-
-
-@tf.custom_gradient
-def _calculate_density_compensator_no_grad(*args):
-    """Internal function that returns density compensators, but also returns
-    no gradients"""
-    dc_weights = _calculate_density_compensator(*args)
-    def grad(dy):
-        return [None for arg in args]
-    return dc_weights, grad
-
-
 def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10, zero_grad=True):
     """Numerical density compensation estimation for a any trajectory.
 

--- a/tfkbnufft/mri/dcomp_calc.py
+++ b/tfkbnufft/mri/dcomp_calc.py
@@ -85,6 +85,7 @@ def calculate_radial_dcomp_tf(interpob, nufftob_forw, nufftob_back, ktraj, stack
     return dcomp
 
 
+@tf.custom_gradient
 def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10):
     """Numerical density compensation estimation for a any trajectory.
 
@@ -129,4 +130,6 @@ def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, n
     ratio = tf.reduce_mean(test_im_recon)
     test_sig = test_sig / tf.cast(ratio, test_sig.dtype)
     test_sig = test_sig[0, 0]
-    return test_sig
+    def grad(dy):
+        return tf.zeros_like(dy)
+    return test_sig, grad

--- a/tfkbnufft/mri/dcomp_calc.py
+++ b/tfkbnufft/mri/dcomp_calc.py
@@ -85,7 +85,7 @@ def calculate_radial_dcomp_tf(interpob, nufftob_forw, nufftob_back, ktraj, stack
     return dcomp
 
 
-def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10, zero_grad=False):
+def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10, zero_grad=True):
     """Numerical density compensation estimation for a any trajectory.
 
     Estimates the density compensation function numerically using a NUFFT
@@ -105,7 +105,7 @@ def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, n
             trajectory.
         num_iterations (int): default 10
             number of iterations
-        zero_grad (bool): default False
+        zero_grad (bool): default True
             when true, assumes that the density compensator is a constant and
             returns zero gradients
 

--- a/tfkbnufft/mri/dcomp_calc.py
+++ b/tfkbnufft/mri/dcomp_calc.py
@@ -85,8 +85,7 @@ def calculate_radial_dcomp_tf(interpob, nufftob_forw, nufftob_back, ktraj, stack
     return dcomp
 
 
-@tf.custom_gradient
-def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10):
+def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10, zero_grad=False):
     """Numerical density compensation estimation for a any trajectory.
 
     Estimates the density compensation function numerically using a NUFFT
@@ -106,6 +105,9 @@ def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, n
             trajectory.
         num_iterations (int): default 10
             number of iterations
+        zero_grad (bool): default False
+            when true, assumes that the density compensator is a constant and
+            returns zero gradients
 
     Returns:
         tensor: The density compensation coefficients for ktraj of size (m).
@@ -118,18 +120,30 @@ def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, n
             interpob
         )), 'complex64')
     im_size = interpob['im_size']
-    test_size = tf.concat([(1, 1,), im_size], axis=0)
-    test_im = tf.ones(test_size, dtype=tf.complex64)
-    test_im_recon = nufftob_back(
-        test_sig * nufftob_forw(
-            test_im,
+
+    def _normalize(sig):
+        test_size = tf.concat([(1, 1,), im_size], axis=0)
+        test_im = tf.ones(test_size, dtype=tf.complex64)
+        test_im_recon = nufftob_back(
+            sig * nufftob_forw(
+                test_im,
+                ktraj[None, :]
+            ),
             ktraj[None, :]
-        ),
-        ktraj[None, :]
-    )
-    ratio = tf.reduce_mean(test_im_recon)
-    test_sig = test_sig / tf.cast(ratio, test_sig.dtype)
-    test_sig = test_sig[0, 0]
-    def grad(dy):
-        return tf.zeros_like(dy)
-    return test_sig, grad
+        )
+        ratio = tf.reduce_mean(test_im_recon)
+        sig = sig / tf.cast(ratio, sig.dtype)
+        sig = sig[0, 0]
+        return sig
+
+    @tf.custom_gradient
+    def _normalize_zero_grad(sig):
+        sig = _normalize(sig)
+        def grad(dy):
+            # We assume that the density compensator is a constant
+            return tf.zeros_like(dy)
+        return sig, grad
+    if zero_grad:
+        return _normalize_zero_grad(test_sig)
+    else:
+        return _normalize(test_sig)

--- a/tfkbnufft/mri/dcomp_calc.py
+++ b/tfkbnufft/mri/dcomp_calc.py
@@ -85,7 +85,65 @@ def calculate_radial_dcomp_tf(interpob, nufftob_forw, nufftob_back, ktraj, stack
     return dcomp
 
 
-def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10, zero_grad=True):
+def _calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10):
+    """Numerical density compensation estimation for a any trajectory.
+
+    Estimates the density compensation function numerically using a NUFFT
+    interpolator operator and a k-space trajectory (ktraj).
+    This function implements Pipe et al
+
+    This function uses a nufft hyper parameter dictionary, the associated nufft
+    operators and k-space trajectory.
+
+    Args:
+        interpob (dict): the output of `KbNufftModule._extract_nufft_interpob`
+            containing all the hyper-parameters for the nufft computation.
+        nufftob_forw (fun)
+        nufftob_back (fun)
+        ktraj (tensor): The k-space trajectory in radians/voxel dimension (d, m).
+            d is the number of spatial dimensions, and m is the length of the
+            trajectory.
+        num_iterations (int): default 10
+            number of iterations
+
+    Returns:
+        tensor: The density compensation coefficients for ktraj of size (m).
+    """
+    test_sig = tf.ones([1, 1, ktraj.shape[1]], dtype=tf.float32)
+    for i in range(num_iterations):
+        test_sig = test_sig / tf.math.abs(kbinterp(
+            adjkbinterp(tf.cast(test_sig, tf.complex64), ktraj[None, :], interpob),
+            ktraj[None, :],
+            interpob
+        ))
+    im_size = interpob['im_size']
+    test_sig = tf.cast(test_sig, tf.complex64)
+    test_size = tf.concat([(1, 1,), im_size], axis=0)
+    test_im = tf.ones(test_size, dtype=tf.complex64)
+    test_im_recon = nufftob_back(
+        test_sig * nufftob_forw(
+            test_im,
+            ktraj[None, :]
+        ),
+        ktraj[None, :]
+    )
+    ratio = tf.reduce_mean(tf.math.abs(test_im_recon))
+    test_sig = test_sig / tf.cast(ratio, test_sig.dtype)
+    test_sig = test_sig[0, 0]
+    return test_sig
+
+
+@tf.custom_gradient
+def _calculate_density_compensator_no_grad(*args):
+    """Internal function that returns density compensators, but also returns
+    no gradients"""
+    dc_weights = _calculate_density_compensator(*args)
+    def grad(dy):
+        return [None for arg in args]
+    return dc_weights, grad
+
+
+def calculate_density_compensator(*args, zero_grad=True):
     """Numerical density compensation estimation for a any trajectory.
 
     Estimates the density compensation function numerically using a NUFFT
@@ -112,38 +170,7 @@ def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, n
     Returns:
         tensor: The density compensation coefficients for ktraj of size (m).
     """
-    test_sig = tf.ones([1, 1, ktraj.shape[1]], dtype=tf.float32)
-    for i in range(num_iterations):
-        test_sig = test_sig / tf.math.abs(kbinterp(
-            adjkbinterp(tf.cast(test_sig, tf.complex64), ktraj[None, :], interpob),
-            ktraj[None, :],
-            interpob
-        ))
-    im_size = interpob['im_size']
-    test_sig = tf.cast(test_sig, tf.complex64)
-    def _normalize(sig):
-        test_size = tf.concat([(1, 1,), im_size], axis=0)
-        test_im = tf.ones(test_size, dtype=tf.complex64)
-        test_im_recon = nufftob_back(
-            sig * nufftob_forw(
-                test_im,
-                ktraj[None, :]
-            ),
-            ktraj[None, :]
-        )
-        ratio = tf.reduce_mean(tf.math.abs(test_im_recon))
-        sig = sig / tf.cast(ratio, sig.dtype)
-        sig = sig[0, 0]
-        return sig
-
-    @tf.custom_gradient
-    def _normalize_zero_grad(sig):
-        sig = _normalize(sig)
-        def grad(dy):
-            # We assume that the density compensator is a constant
-            return tf.zeros_like(dy)
-        return sig, grad
     if zero_grad:
-        return _normalize_zero_grad(test_sig)
+        return _calculate_density_compensator_no_grad(*args)
     else:
-        return _normalize(test_sig)
+        return _calculate_density_compensator(*args)

--- a/tfkbnufft/mri/dcomp_calc.py
+++ b/tfkbnufft/mri/dcomp_calc.py
@@ -112,15 +112,15 @@ def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, n
     Returns:
         tensor: The density compensation coefficients for ktraj of size (m).
     """
-    test_sig = tf.ones([1, 1, ktraj.shape[1]], dtype=tf.complex64)
+    test_sig = tf.ones([1, 1, ktraj.shape[1]], dtype=tf.float32)
     for i in range(num_iterations):
-        test_sig = test_sig / tf.cast(tf.math.abs(kbinterp(
-            adjkbinterp(test_sig, ktraj[None, :], interpob),
+        test_sig = test_sig / tf.math.abs(kbinterp(
+            adjkbinterp(tf.cast(test_sig, tf.complex64), ktraj[None, :], interpob),
             ktraj[None, :],
             interpob
-        )), 'complex64')
+        ))
     im_size = interpob['im_size']
-
+    test_sig = tf.cast(test_sig, tf.complex64)
     def _normalize(sig):
         test_size = tf.concat([(1, 1,), im_size], axis=0)
         test_im = tf.ones(test_size, dtype=tf.complex64)
@@ -131,7 +131,7 @@ def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, n
             ),
             ktraj[None, :]
         )
-        ratio = tf.reduce_mean(test_im_recon)
+        ratio = tf.reduce_mean(tf.math.abs(test_im_recon))
         sig = sig / tf.cast(ratio, sig.dtype)
         sig = sig[0, 0]
         return sig

--- a/tfkbnufft/mri/dcomp_calc.py
+++ b/tfkbnufft/mri/dcomp_calc.py
@@ -85,52 +85,7 @@ def calculate_radial_dcomp_tf(interpob, nufftob_forw, nufftob_back, ktraj, stack
     return dcomp
 
 
-def _calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10):
-    """Numerical density compensation estimation for a any trajectory.
 
-    Estimates the density compensation function numerically using a NUFFT
-    interpolator operator and a k-space trajectory (ktraj).
-    This function implements Pipe et al
-
-    This function uses a nufft hyper parameter dictionary, the associated nufft
-    operators and k-space trajectory.
-
-    Args:
-        interpob (dict): the output of `KbNufftModule._extract_nufft_interpob`
-            containing all the hyper-parameters for the nufft computation.
-        nufftob_forw (fun)
-        nufftob_back (fun)
-        ktraj (tensor): The k-space trajectory in radians/voxel dimension (d, m).
-            d is the number of spatial dimensions, and m is the length of the
-            trajectory.
-        num_iterations (int): default 10
-            number of iterations
-
-    Returns:
-        tensor: The density compensation coefficients for ktraj of size (m).
-    """
-    test_sig = tf.ones([1, 1, ktraj.shape[1]], dtype=tf.float32)
-    for i in range(num_iterations):
-        test_sig = test_sig / tf.math.abs(kbinterp(
-            adjkbinterp(tf.cast(test_sig, tf.complex64), ktraj[None, :], interpob),
-            ktraj[None, :],
-            interpob
-        ))
-    im_size = interpob['im_size']
-    test_sig = tf.cast(test_sig, tf.complex64)
-    test_size = tf.concat([(1, 1,), im_size], axis=0)
-    test_im = tf.ones(test_size, dtype=tf.complex64)
-    test_im_recon = nufftob_back(
-        test_sig * nufftob_forw(
-            test_im,
-            ktraj[None, :]
-        ),
-        ktraj[None, :]
-    )
-    ratio = tf.reduce_mean(tf.math.abs(test_im_recon))
-    test_sig = test_sig / tf.cast(ratio, test_sig.dtype)
-    test_sig = test_sig[0, 0]
-    return test_sig
 
 
 @tf.custom_gradient
@@ -143,7 +98,7 @@ def _calculate_density_compensator_no_grad(*args):
     return dc_weights, grad
 
 
-def calculate_density_compensator(*args, zero_grad=True):
+def calculate_density_compensator(interpob, nufftob_forw, nufftob_back, ktraj, num_iterations=10, zero_grad=True):
     """Numerical density compensation estimation for a any trajectory.
 
     Estimates the density compensation function numerically using a NUFFT
@@ -170,7 +125,40 @@ def calculate_density_compensator(*args, zero_grad=True):
     Returns:
         tensor: The density compensation coefficients for ktraj of size (m).
     """
+    def _calculate_density_compensator(ktraj):
+        test_sig = tf.ones([1, 1, ktraj.shape[1]], dtype=tf.float32)
+        for i in range(num_iterations):
+            test_sig = test_sig / tf.math.abs(kbinterp(
+                adjkbinterp(tf.cast(test_sig, tf.complex64), ktraj[None, :], interpob),
+                ktraj[None, :],
+                interpob
+            ))
+        im_size = interpob['im_size']
+        test_sig = tf.cast(test_sig, tf.complex64)
+        test_size = tf.concat([(1, 1,), im_size], axis=0)
+        test_im = tf.ones(test_size, dtype=tf.complex64)
+        test_im_recon = nufftob_back(
+            test_sig * nufftob_forw(
+                test_im,
+                ktraj[None, :]
+            ),
+            ktraj[None, :]
+        )
+        ratio = tf.reduce_mean(tf.math.abs(test_im_recon))
+        test_sig = test_sig / tf.cast(ratio, test_sig.dtype)
+        test_sig = test_sig[0, 0]
+        return test_sig
+
+    @tf.custom_gradient
+    def _calculate_density_compensator_no_grad(ktraj):
+        """Internal function that returns density compensators, but also returns
+        no gradients"""
+        dc_weights = _calculate_density_compensator(ktraj)
+        def grad(dy):
+            return None
+        return dc_weights, grad
+
     if zero_grad:
-        return _calculate_density_compensator_no_grad(*args)
+        return _calculate_density_compensator_no_grad(ktraj)
     else:
-        return _calculate_density_compensator(*args)
+        return _calculate_density_compensator(ktraj)

--- a/tfkbnufft/tests/kbnufft_test.py
+++ b/tfkbnufft/tests/kbnufft_test.py
@@ -60,4 +60,4 @@ def test_forward_gradient(multiprocessing):
         res = forward_op(image, traj)
     grad = tape.gradient(res, image)
     tf_test = tf.test.TestCase()
-    tf_test.assertEqual(grad.shape, 1)
+    tf_test.assertEqual(grad.shape, image.shape)

--- a/tfkbnufft/tests/kbnufft_test.py
+++ b/tfkbnufft/tests/kbnufft_test.py
@@ -60,4 +60,4 @@ def test_forward_gradient(multiprocessing):
         res = forward_op(image, traj)
     grad = tape.gradient(res, image)
     tf_test = tf.test.TestCase()
-    tf_test.assertEqual(grad.shape, image.shape)
+    tf_test.assertEqual(grad.shape, 1)

--- a/tfkbnufft/tests/mri/dcomp_calc_test.py
+++ b/tfkbnufft/tests/mri/dcomp_calc_test.py
@@ -57,4 +57,5 @@ def test_density_compensators_tf():
     tf_ktraj = tf.convert_to_tensor(ktraj)
     nufftob_back = kbnufft_adjoint(interpob)
     nufftob_forw = kbnufft_forward(interpob)
-    tf_dcomp = calculate_density_compensator(interpob, nufftob_forw, nufftob_back, tf_ktraj)
+    tf_dcomp = calculate_density_compensator(interpob, nufftob_forw, nufftob_back, tf_ktraj, zero_grad=False)
+    tf_dcomp_no_grad = calculate_density_compensator(interpob, nufftob_forw, nufftob_back, tf_ktraj, zero_grad=True)


### PR DESCRIPTION
We can assume that the density compensation is constant and does not vary with trajectory.

This will help in better learning trajectory and not be affected by gradients, which can end up having noise in them.

Also this resolves #39